### PR TITLE
Build tags

### DIFF
--- a/ardent.go
+++ b/ardent.go
@@ -1,45 +1,24 @@
 package ardent
 
-import (
-	"github.com/split-cube-studios/ardent/engine"
-	"github.com/split-cube-studios/ardent/internal/ebiten"
-	"github.com/split-cube-studios/ardent/internal/headless"
-)
+import "github.com/split-cube-studios/ardent/engine"
 
-// Backend flag type
-type Backend byte
-
-// Backend options
-const (
-	HEADLESS Backend = 1 << iota
-	EBITEN
-)
-
-// NewGame creates a new game instance for a given backend.
+// NewGame creates a new game instance.
+//
+// The backend can be selected with one of the following build tags:
+//  ebiten
+//  headless
 func NewGame(
 	title string,
 	w, h int,
 	flags byte,
-	backend Backend,
 	tickFunc func(),
 	layoutFunc func(int, int) (int, int),
 ) engine.Game {
-	switch backend {
-	case HEADLESS:
-		return headless.NewGame(
-			tickFunc,
-			nil,
-		)
-	case EBITEN:
-		return ebiten.NewGame(
-			title,
-			w,
-			h,
-			flags,
-			tickFunc,
-			layoutFunc,
-		)
-	default:
-		panic("Invalid backend")
-	}
+	return newGame(
+		title,
+		w, h,
+		flags,
+		tickFunc,
+		layoutFunc,
+	)
 }

--- a/ardent.go
+++ b/ardent.go
@@ -4,9 +4,8 @@ import "github.com/split-cube-studios/ardent/engine"
 
 // NewGame creates a new game instance.
 //
-// The backend can be selected with one of the following build tags:
-//  ebiten
-//  headless
+// The backend can be selected with build tags.
+// The default, with no tag, is to use Ebiten.
 func NewGame(
 	title string,
 	w, h int,

--- a/backend_ebiten.go
+++ b/backend_ebiten.go
@@ -1,0 +1,25 @@
+// +build !headless
+
+package ardent
+
+import (
+	"github.com/split-cube-studios/ardent/engine"
+	"github.com/split-cube-studios/ardent/internal/ebiten"
+)
+
+func newGame(
+	title string,
+	w, h int,
+	flags byte,
+	tickFunc func(),
+	layoutFunc func(int, int) (int, int),
+) engine.Game {
+	return ebiten.NewGame(
+		title,
+		w,
+		h,
+		flags,
+		tickFunc,
+		layoutFunc,
+	)
+}

--- a/backend_headless.go
+++ b/backend_headless.go
@@ -1,0 +1,21 @@
+// +build headless
+
+package ardent
+
+import (
+	"github.com/split-cube-studios/ardent/engine"
+	"github.com/split-cube-studios/ardent/internal/headless"
+)
+
+func newGame(
+	title string,
+	w, h int,
+	flags byte,
+	tickFunc func(),
+	layoutFunc func(int, int) (int, int),
+) engine.Game {
+	return headless.NewGame(
+		tickFunc,
+		nil,
+	)
+}

--- a/examples/animation/main.go
+++ b/examples/animation/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/split-cube-studios/ardent"
 	"github.com/split-cube-studios/ardent/assetutil"
 	"github.com/split-cube-studios/ardent/engine"
-	"log"
-	"os"
 )
 
 var (
@@ -21,8 +22,6 @@ func main() {
 		854,
 		480,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		func() {
 			// change animation every 120 ticks

--- a/examples/atlas/main.go
+++ b/examples/atlas/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/split-cube-studios/ardent/assetutil"
 	"log"
 	"math"
 
 	"github.com/split-cube-studios/ardent"
+	"github.com/split-cube-studios/ardent/assetutil"
 	"github.com/split-cube-studios/ardent/engine"
 )
 
@@ -16,8 +16,6 @@ func main() {
 		854,
 		480,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		func() {},
 		// layout function

--- a/examples/camera/main.go
+++ b/examples/camera/main.go
@@ -43,8 +43,6 @@ func main() {
 		w,
 		h,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		tick,
 		// layout function

--- a/examples/image/main.go
+++ b/examples/image/main.go
@@ -13,8 +13,6 @@ func main() {
 		854,
 		480,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		func() {},
 		// layout function

--- a/examples/isometric/main.go
+++ b/examples/isometric/main.go
@@ -24,8 +24,6 @@ func main() {
 		w,
 		h,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		func() {
 			if game.IsKeyPressed(engine.KeyW) {

--- a/examples/keyboard/main.go
+++ b/examples/keyboard/main.go
@@ -33,8 +33,6 @@ func main() {
 		854,
 		480,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		tick,
 		// layout function

--- a/examples/mouse/main.go
+++ b/examples/mouse/main.go
@@ -24,8 +24,6 @@ func main() {
 		854,
 		480,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		tick,
 		// layout function

--- a/examples/text/main.go
+++ b/examples/text/main.go
@@ -15,8 +15,6 @@ func main() {
 		854,
 		480,
 		engine.FlagResizable,
-		// use Ebiten backend
-		ardent.EBITEN,
 		// tick function
 		func() {},
 		// layout function


### PR DESCRIPTION
fixes #10.

currently defaults to using ebiten, and switches to headless with the `headless` tag.