### PR TITLE
Modify custom asset format to use gob

### DIFF
--- a/assetutil/assetutil.go
+++ b/assetutil/assetutil.go
@@ -57,7 +57,7 @@ func CreateAssets(dir string) {
 			log.Fatal(err)
 		}
 
-		d, err := asset.MarshalBinary()
+		d, err := asset.Marshal()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/assetutil/config.go
+++ b/assetutil/config.go
@@ -78,7 +78,7 @@ func (c config) toAsset() (*common.Asset, error) {
 	}
 	defer f.Close()
 
-	asset.Img, err = png.Decode(f)
+	asset.Img.Image, err = png.Decode(f)
 
 	return asset, err
 }

--- a/internal/ebiten/asset.go
+++ b/internal/ebiten/asset.go
@@ -33,7 +33,7 @@ func (a *Asset) ToAnimation() engine.Animation {
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
 func (a *Asset) UnmarshalBinary(data []byte) error {
 	ca := common.NewAsset()
-	if err := ca.UnmarshalBinary(data); err != nil {
+	if err := ca.Unmarshal(data); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
To accomplish this, a few modifications has been made internally.

The new file format is simply "Ardent", followed by a null byte, followed by gob-encoded data.
An image is encoded as either a null byte (not an image) or a PNG file. This is done as PNG's header will never start with a null byte.

Note that the new file format starts with "Ardent" instead of "ardent" to prevent old and new file format from colliding.

The MarshalBinary and UnmarshalBinary function of asset has been replaced by Marshal and Unmarshal respectively to make sure gob doesn't pick them up and use them, causing an endless loop as we do call gob in those functions now.

The Image field of an asset is now a struct that embeds image.Image.
This allows MarshalBinary and UnmarshalBinary to be implemented on top of it.

Resolves #15.