### PR TITLE
Fix camera example lerp rate

### DIFF
--- a/examples/camera/main.go
+++ b/examples/camera/main.go
@@ -35,7 +35,9 @@ func tick() {
 	}
 
 	stripes.Translate(x, y)
-	camera.LookAt(x+float64(stripeWidth/2), y+float64(stripeHeight/2), 0)
+
+	// 0.05 lerp rate
+	camera.LookAt(x+float64(stripeWidth/2), y+float64(stripeHeight/2), 0.05)
 }
 
 func main() {


### PR DESCRIPTION
Lerp rate in the camera example was 0, meaning no camera movement. I've set it to a small value to demonstrate the camera follow effect.