### PR TITLE
engine: be more precise in Vec2 documentation

### DIFF
--- a/engine/vec2.go
+++ b/engine/vec2.go
@@ -8,13 +8,13 @@ type Vec2 struct {
 }
 
 // AngleTo returns the angle in radians
-// between two vectors.
+// from the endpoint of v to the endpoint of v2.
 func (v Vec2) AngleTo(v2 Vec2) float64 {
 	return math.Atan2(v2.Y-v.Y, v2.X-v.X)
 }
 
-// Lerp returns the linear interpolation between
-// two vectors by percent t.
+// Lerp returns the linear interpolation from v to v2
+// by proportion t.
 func (v Vec2) Lerp(v2 Vec2, t float64) Vec2 {
 	return Vec2{
 		X: (1-t)*v.X + t*v2.X,
@@ -22,7 +22,7 @@ func (v Vec2) Lerp(v2 Vec2, t float64) Vec2 {
 	}
 }
 
-// Distance returns the distance between two vectors.
+// Distance returns the distance between the endpoints of v and v2.
 func (v Vec2) Distance(v2 Vec2) float64 {
 	return math.Sqrt(
 		math.Pow(v2.X-v.X, 2) +
@@ -30,8 +30,8 @@ func (v Vec2) Distance(v2 Vec2) float64 {
 	)
 }
 
-// Translate returns the translation of a vector
-// towards direction d by magnitude m.
+// Translate returns the translation of v
+// along angle d in radians by magnitude m.
 func (v Vec2) Translate(d float64, m float64) Vec2 {
 	return Vec2{
 		X: v.X + math.Cos(d)*m,


### PR DESCRIPTION
Most of the methods of Vec2 are non-commutative, so be precise about "from" and "to". Also, for AngleTo and Distance, be
precise that we mean "between endpoints," and specifically that AngleTo is not the angle between.

Fixes #44.