### PR TITLE
engine: various minor code improvements

### DIFF
--- a/engine/angles.go
+++ b/engine/angles.go
@@ -19,7 +19,7 @@ const diag = 3.435 * math.Pi / 180
 
 // CardinalToAngle is a map of cardinal directions
 // to angles in dimetric space.
-var CardinalToAngle = map[byte]float64{
+var CardinalToAngle = [...]float64{
 	N:  3 * math.Pi / 2,            // 90
 	E:  0,                          // 0
 	S:  math.Pi / 2,                // 270

--- a/engine/statemachine.go
+++ b/engine/statemachine.go
@@ -24,7 +24,7 @@ func (sm *StateMachine) UpdateState(state uint64, active bool) {
 	if active {
 		sm.state |= state
 	} else {
-		sm.state &= ^state
+		sm.state &^= state
 	}
 }
 
@@ -50,13 +50,13 @@ func (sm *StateMachine) State() uint64 {
 
 // Is indicates whether a given state is active.
 func (sm *StateMachine) Is(state uint64) bool {
-	return sm.state&state > 0
+	return sm.state&state != 0
 }
 
 // IsOnly indicates whether a given state is active,
 // and that it is the only active state.
 func (sm *StateMachine) IsOnly(state uint64) bool {
-	return sm.state & ^state == 0
+	return sm.state&^state == 0
 }
 
 // SetCallback sets a given callback function for a given state.

--- a/engine/vec2.go
+++ b/engine/vec2.go
@@ -24,17 +24,18 @@ func (v Vec2) Lerp(v2 Vec2, t float64) Vec2 {
 
 // Distance returns the distance between the endpoints of v and v2.
 func (v Vec2) Distance(v2 Vec2) float64 {
-	return math.Sqrt(
-		math.Pow(v2.X-v.X, 2) +
-			math.Pow(v2.Y-v.Y, 2),
-	)
+	dy, dx := v2.Y-v.Y, v2.X-v.X
+	// math.Hypot(dy, dx) is more precise near over- and underflow, but it's
+	// slower, and those conditions should be rare[citation needed].
+	return math.Sqrt(dy*dy + dx*dx)
 }
 
 // Translate returns the translation of v
 // along angle d in radians by magnitude m.
 func (v Vec2) Translate(d float64, m float64) Vec2 {
+	dy, dx := math.Sincos(d)
 	return Vec2{
-		X: v.X + math.Cos(d)*m,
-		Y: v.Y + math.Sin(d)*m,
+		X: v.X + dx*m,
+		Y: v.Y + dy*m,
 	}
 }


### PR DESCRIPTION
Vec2.Distance should now be much faster.
Vec2.Translate might be somewhat faster.
Lookups in CardinalToAngle should be significantly faster, as it is now an array instead of a map.
Go has an &^ operator for bit-clear.